### PR TITLE
Feat/55/automatic builtversion creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,14 @@
 Never change this AGENTS.md without explicit user consent.
 
-Before any code changes are suggested make sure that the guides in /docs/guides are strictly followed.
-
 When considering an implementation go for the easiest implementation with a little complexitiy as possible. Go for the simple solution. Change only what is necessary to fullfill the given task.
 
 Whenever we start a session, sumarize a random paragraph of any .md file in the /docs/guide directory to refresh the memory of the user. Start this section with "As requested in AGENTS.md, some documentation: "
+
+## Documentation
+
+Before any code changes are suggested make sure that the guides in /docs/guides are strictly followed.
+
+After changes were made always scan the docs/business_logic for necessary updates. This directory should always reflect the business logic of the application.
 
 ## Available Tools
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ A quick map of this repository’s docs and guides. Each entry links to a source
 - [guides/business_logic/entity_management_policies](guides/business_logic/entity_management_policies.md) — how to add new domain entities and keep server/client in sync.
 - [guides/business_logic/service_conventions](guides/business_logic/service_conventions.md) — service design patterns (semantic IDs, SRP, transitions API).
 - [guides/business_logic/built_version](guides/business_logic/built_version.md) — Built Version creation side effects, status lifecycle (history), and client caching.
+- [guides/business_logic/release_component_naming](guides/business_logic/release_component_naming.md) — tokens, increments, and token snapshot persistence for component naming.
 - [guides/business_logic/error_handling_policy](guides/business_logic/error_handling_policy.md) — current error handling approach and known limitations.
 
 ### Database Design

--- a/docs/guides/business_logic/built_version.md
+++ b/docs/guides/business_logic/built_version.md
@@ -1,37 +1,39 @@
 # Built Version: Behavior & Side Effects
 
-This document explains the behavior of `BuiltVersion` creation and lifecycle derivation.
+This document explains how Built Versions are created, named, and how their lifecycle and UI updates are derived.
 
-## Creation Side Effects
+## Automatic Creation & Naming
 
-When a Built Version is created (`BuiltVersionService.create`):
+- On Release creation: An initial Built Version is automatically created with name pattern `{release_version}.{increment}` using increment `0` (e.g., `version 178.0`).
+- On transition to deployment: When a Built Version transitions from `in_development` to `in_deployment`, a successor Built Version is automatically created for the same Release with the next increment (e.g., `version 178.1`).
+- Successor guard: A successor is only created if no newer Built Version already exists for that Release. If a newer build exists, no additional build (e.g., `.3`) is created.
+- Release-scoped increment: The increment for Built Version names is tracked on `ReleaseVersion.lastUsedIncrement` and increases per Release (starts at `-1`, first auto build is `0`).
 
-- The service expands naming patterns for all `ReleaseComponent` rows using tokens:
-  - `{release_version}`, `{built_version}`, `{increment}`
-- For each component, it creates a `ComponentVersion` row with an increment scoped to `(builtVersionId + componentId)`.
-- This happens in a single transaction with the Built Version creation.
+## Token Snapshots
 
-Implications:
-- Creating a Built Version will always produce corresponding Component Version labels for all configured components.
-- If a component has an invalid/empty pattern, the service skips it (defensive handling), leaving other components unaffected.
+To make name generation reproducible and auditable:
+- `BuiltVersion.tokenValues` stores `{ "release_version": string, "increment": number }`.
+- `ComponentVersion.tokenValues` stores `{ "release_version": string, "built_version": string, "increment": number }`.
+
+## Component Versions on Build Creation
+
+Whenever a Built Version is created (initial or successor):
+- The service expands naming patterns for all `ReleaseComponent`s using tokens `{release_version}`, `{built_version}`, `{increment}`.
+- For each component, a `ComponentVersion` row is created with `increment` scoped per `(builtVersionId + componentId)`, starting at `0`.
+- Invalid/empty patterns are skipped defensively without affecting other components.
 
 ## Lifecycle & Status Derivation (History-Driven)
 
 - There is no `status` column on `BuiltVersion`.
 - Current status is computed from the latest `BuiltVersionTransition` entry.
   - No history → `in_development`.
-  - All transitions (forward/backward) are append-only and validated by `BuiltVersionStatusService`.
-- Transitions are reversible via explicit actions (`cancelDeployment`, `revertToDeployment`, `reactivate`).
+  - Transitions are append-only and validated by `BuiltVersionStatusService`.
+- Reversible actions: `cancelDeployment`, `revertToDeployment`, `reactivate`.
 
-Key files:
-- History model: `prisma/schema.prisma` → `BuiltVersionTransition` + enums
-- Service: `src/server/services/built-version-status.service.ts`
-- API: `src/server/api/routers/built-version.ts` (`getStatus`, `transition`)
-
-## Allowed Transitions
+### Allowed Transitions
 
 From `in_development`:
-- `startDeployment` → `in_deployment`
+- `startDeployment` → `in_deployment` (triggers successor creation if no newer build exists)
 
 From `in_deployment`:
 - `markActive` → `active`
@@ -43,9 +45,14 @@ From `active`:
 
 From `deprecated`:
 - `reactivate` → `active`
-## Client Caching (Built Versions Page)
 
-- The page `src/app/versions/builds/page.tsx` caches the releases-with-builds response in `localStorage` under the key `jrm:builds:releases-with-builds:v1`.
-- Cache is used as placeholder data between navigations and refreshed on demand.
-- Bump the key suffix (e.g., `v2`) when the response shape changes to avoid stale rendering.
+## UI Behavior
 
+- Builds page (`src/app/versions/builds/page.tsx`) invalidates and refetches the releases-with-builds list only after a successful `startDeployment` transition, ensuring the auto-created successor appears immediately. Other transitions do not trigger a list reload.
+- The page caches the releases-with-builds response in `localStorage` under `jrm:builds:releases-with-builds:v1` as placeholder data and refreshes on demand.
+
+## Key Files
+
+- Prisma models: `prisma/schema.prisma` (`ReleaseVersion.lastUsedIncrement`, `BuiltVersion.tokenValues`, `ComponentVersion.tokenValues`, `BuiltVersionTransition` + enums)
+- Services: `src/server/services/release-version.service.ts`, `src/server/services/built-version-status.service.ts`
+- API: `src/server/api/routers/built-version.ts` (`getStatus`, `transition`)

--- a/docs/guides/business_logic/release_component_naming.md
+++ b/docs/guides/business_logic/release_component_naming.md
@@ -1,0 +1,31 @@
+# Release Component Naming
+
+This guide defines how names for `ComponentVersion` are generated and where token values are persisted.
+
+## Allowed Tokens
+
+- `{release_version}` — the Release Version name (e.g., `version 178`)
+- `{built_version}` — the Built Version name (e.g., `version 178.0`)
+- `{increment}` — per‑component increment for this Built Version, starting at `0`
+
+Patterns are validated; unknown tokens or unbalanced braces are rejected. Empty/invalid patterns are skipped during generation, leaving other components unaffected.
+
+## Token Snapshots (Persistence)
+
+To make generated names reproducible and auditable, token values are stored alongside the records:
+
+- `BuiltVersion.tokenValues` — `{ "release_version": string, "increment": number }`
+- `ComponentVersion.tokenValues` — `{ "release_version": string, "built_version": string, "increment": number }`
+
+These snapshots capture the exact values used when expanding the pattern for later inspection or re‑rendering.
+
+## Increment Semantics
+
+- Component increments are scoped per `(builtVersionId, releaseComponentId)` and start at `0` for each newly created Built Version.
+- Built Version name increments are release‑scoped and tracked using `ReleaseVersion.lastUsedIncrement` (first auto build uses `0`).
+
+## References
+
+- Schema: `prisma/schema.prisma`
+- Naming helpers: `src/server/services/component-version-naming.service.ts`
+- Creation: `src/server/services/release-version.service.ts`, `src/server/services/built-version.service.ts`

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,17 @@
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: "node",
+  extensionsToTreatAsEsm: [".ts"],
+  transform: {
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      { useESM: true, tsconfig: "tsconfig.json", isolatedModules: true },
+    ],
+  },
+  moduleNameMapper: {
+    // Map TS path alias '~/' to src/ for Jest
+    "^~/(.*)$": "<rootDir>/src/$1",
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "preview": "next build && next start",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test-all": "jest && pnpm test:db-schema",
+    "test:all": "jest && pnpm test:db-schema",
     "test": "jest",
+    "test:services": "jest tests/services",
     "test:db-schema": "node tests/scripts/test-lint-db-schema.mjs"
   },
   "engines": {
@@ -77,6 +78,7 @@
     "prisma": "^6.16.0",
     "prisma-zod-generator": "^1.20.2",
     "tailwindcss": "^4.1.13",
+    "ts-jest": "^29.4.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.43.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
+      ts-jest:
+        specifier: ^29.4.2
+        version: 29.4.2(@babel/core@7.28.4)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.4))(jest-util@30.0.5)(jest@30.1.3(@types/node@20.19.13))(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -1444,6 +1447,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
@@ -2042,6 +2049,11 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2548,6 +2560,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2572,6 +2587,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -2633,6 +2651,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next-auth@5.0.0-beta.25:
     resolution: {integrity: sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==}
@@ -3288,6 +3309,33 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-jest@29.4.2:
+    resolution: {integrity: sha512-pBNOkn4HtuLpNrXTMVRC9b642CBaDnKqWXny4OzuoULT9S7Kf8MMlaRe2veKax12rjf5WcpMBhVPbQurlWGNxA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -3305,6 +3353,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3332,6 +3384,11 @@ packages:
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -3392,6 +3449,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4845,6 +4905,10 @@ snapshots:
       node-releases: 2.0.20
       update-browserslist-db: 1.1.3(browserslist@4.25.4)
 
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -5588,6 +5652,15 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -6250,6 +6323,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.memoize@4.1.2: {}
+
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
@@ -6273,6 +6348,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.2
+
+  make-error@1.3.6: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -6316,6 +6393,8 @@ snapshots:
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
+
+  neo-async@2.6.2: {}
 
   next-auth@5.0.0-beta.25(next@15.5.2(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -6965,6 +7044,26 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
+  ts-jest@29.4.2(@babel/core@7.28.4)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.4))(jest-util@30.0.5)(jest@30.1.3(@types/node@20.19.13))(typescript@5.9.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 30.1.3(@types/node@20.19.13)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.2
+      type-fest: 4.41.0
+      typescript: 5.9.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 30.1.2
+      '@jest/types': 30.0.5
+      babel-jest: 30.1.2(@babel/core@7.28.4)
+      jest-util: 30.0.5
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -6981,6 +7080,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7027,6 +7128,9 @@ snapshots:
       - supports-color
 
   typescript@5.9.2: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -7131,6 +7235,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,9 @@ model ReleaseVersion {
     name          String         @unique
     // componentVersions ComponentVersion[]
     builtVersions BuiltVersion[]
+    /// Tracks the last used builtVersion increment for this release
+    /// Starts at -1 so the first auto-created builtVersion gets increment 0
+    lastUsedIncrement Int           @default(-1)
 
     createdAt   DateTime @default(now())
     updatedAt   DateTime @updatedAt
@@ -177,6 +180,8 @@ model BuiltVersion {
     name              String
     version           ReleaseVersion     @relation(fields: [versionId], references: [id])
     versionId         String             @db.Uuid
+    /// Snapshot of tokens used to generate this built version's name
+    tokenValues       Json
     componentVersions ComponentVersion[]
 
     createdAt              DateTime                 @default(now())
@@ -214,6 +219,8 @@ model ComponentVersion {
     builtVersionId     String           @db.Uuid
     name               String
     increment          Int
+    /// Snapshot of tokens used to generate this component version's name
+    tokenValues        Json
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,35 +47,14 @@ enum BuiltVersionAction {
     @@schema("app")
 }
 
-/**
- * model ReleaseComponent {
- * id                 String             @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
- * repository         String?            @unique
- * displayName        String
- * releaseNamePattern String
- * componentVersions  ComponentVersion[]
- * createdAt DateTime @default(now())
- * updatedAt DateTime @updatedAt
- * }
- * model JiraRelease {
- * id                String             @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
- * name              String             @unique
- * syncedAt          DateTime?
- * componentVersions ComponentVersion[]
- * builtVersions     BuiltVersion[]
- * createdAt DateTime @default(now())
- * updatedAt DateTime @updatedAt
- * }
- */
-
 model ReleaseVersion {
-    id            String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-    name          String         @unique
+    id                String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
+    name              String         @unique
     // componentVersions ComponentVersion[]
-    builtVersions BuiltVersion[]
+    builtVersions     BuiltVersion[]
     /// Tracks the last used builtVersion increment for this release
     /// Starts at -1 so the first auto-created builtVersion gets increment 0
-    lastUsedIncrement Int           @default(-1)
+    lastUsedIncrement Int            @default(-1)
 
     createdAt   DateTime @default(now())
     updatedAt   DateTime @updatedAt
@@ -86,34 +65,6 @@ model ReleaseVersion {
     @@index([createdById])
     @@schema("app")
 }
-
-/**
- * model ComponentVersion {
- * id          String           @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
- * component   ReleaseComponent @relation(fields: [componentId], references: [id])
- * componentId String           @db.Uuid
- * release     JiraRelease?     @relation(fields: [releaseId], references: [id])
- * releaseId   String?          @db.Uuid
- * version     ReleaseVersion   @relation(fields: [versionId], references: [id])
- * versionId   String           @db.Uuid
- * createdAt DateTime @default(now())
- * updatedAt DateTime @updatedAt
- * @@index([componentId])
- * @@index([releaseId])
- * @@index([versionId])
- * }
- * model BuiltVersion {
- * id        String         @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
- * release   JiraRelease?   @relation(fields: [releaseId], references: [id])
- * releaseId String?        @db.Uuid
- * version   ReleaseVersion @relation(fields: [versionId], references: [id])
- * versionId String         @db.Uuid
- * createdAt DateTime @default(now())
- * updatedAt DateTime @updatedAt
- * @@index([releaseId])
- * @@index([versionId])
- * }
- */
 
 model User {
     id                     String                   @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid

--- a/src/app/versions/builds/components/built-version-card.tsx
+++ b/src/app/versions/builds/components/built-version-card.tsx
@@ -43,8 +43,13 @@ export default function BuiltVersionCard({
   const currentStatus = (statusData?.status ?? "in_development") as BuiltVersionStatus;
   const utils = api.useUtils();
   const transition = api.builtVersion.transition.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       await utils.builtVersion.getStatus.invalidate({ builtVersionId: id });
+      // Only refresh the builds list when moving from in_development → in_deployment,
+      // which is triggered via the 'startDeployment' action and creates a successor build.
+      if (variables?.action === "startDeployment") {
+        await utils.builtVersion.listReleasesWithBuilds.invalidate();
+      }
     },
   });
 

--- a/src/app/versions/builds/page.tsx
+++ b/src/app/versions/builds/page.tsx
@@ -5,7 +5,6 @@ import { api } from "~/trpc/react";
 import type { ReleaseVersionWithBuildsDto } from "~/shared/types/release-version-with-builds";
 import { Button } from "~/components/ui/button";
 import { RefreshCw } from "lucide-react";
-import AddBuiltVersionCard from "./components/add-built-version-card";
 import BuiltVersionCard from "./components/built-version-card";
 
 export default function VersionsBuildsPage() {
@@ -85,26 +84,6 @@ export default function VersionsBuildsPage() {
             </span>
           </div>
           <div className="relative grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
-            <AddBuiltVersionCard
-              versionId={rel.id}
-              onCreated={(created) => {
-                // Optimistically update cache for this release
-                utils.builtVersion.listReleasesWithBuilds.setData(
-                  undefined,
-                  (old) =>
-                    (old ?? []).map((it) =>
-                      it.id === rel.id
-                        ? {
-                            ...it,
-                            builtVersions: it.builtVersions.some(x => x.id === created.id)
-                              ? it.builtVersions
-                              : [created, ...it.builtVersions],
-                          }
-                        : it,
-                    ),
-                );
-              }}
-            />
             {rel.builtVersions.map((b) => (
               <BuiltVersionCard
                 key={b.id}

--- a/tests/services/release-version.service.test.ts
+++ b/tests/services/release-version.service.test.ts
@@ -1,0 +1,145 @@
+import { ReleaseVersionService } from "~/server/services/release-version.service";
+import { BuiltVersionService } from "~/server/services/built-version.service";
+import { BuiltVersionStatusService } from "~/server/services/built-version-status.service";
+
+// Minimal Prisma-like client mock with only fields used in tests
+function makeMockDb() {
+  const calls: Record<string, unknown[]> = {};
+  const record = (key: string, payload: unknown) => {
+    calls[key] = calls[key] ?? [];
+    calls[key]!.push(payload);
+  };
+
+  const REL_ID = "11111111-1111-1111-1111-111111111111";
+  let builtAutoInc = 0;
+  const makeUuid = (n: number) => {
+    const hex = n.toString(16).padStart(12, "0");
+    return `00000000-0000-0000-0000-${hex}`;
+  };
+
+  const db: any = {
+    $transaction: async (fn: (tx: any) => Promise<any>) => {
+      return await fn(db);
+    },
+    // ReleaseVersion
+    releaseVersion: {
+      create: jest.fn(async (args: any) => {
+        record("releaseVersion.create", args);
+        return { id: REL_ID, name: args.data.name, createdAt: new Date() };
+      }),
+      update: jest.fn(async (args: any) => {
+        record("releaseVersion.update", args);
+        return { id: args.where.id, lastUsedIncrement: args.data.lastUsedIncrement };
+      }),
+      findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    // BuiltVersion
+    builtVersion: {
+      create: jest.fn(async (args: any) => {
+        record("builtVersion.create", args);
+        const id = makeUuid(++builtAutoInc);
+        const versionId = args.data.version?.connect?.id ?? REL_ID;
+        return { id, name: args.data.name, versionId, createdAt: new Date() };
+      }),
+      update: jest.fn(async (args: any) => {
+        record("builtVersion.update", args);
+        return { id: args.where.id, ...args.data };
+      }),
+      findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(async (args: any) => ({ id: args.where.id })),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+    // ReleaseComponent
+    releaseComponent: {
+      findMany: jest.fn(async () => {
+        record("releaseComponent.findMany", {});
+        return [
+          { id: "comp-a", namingPattern: "{release_version}-{built_version}-{increment}" },
+          { id: "comp-b", namingPattern: "{release_version}-{built_version}-{increment}" },
+        ];
+      }),
+    },
+    // ComponentVersion
+    componentVersion: {
+      create: jest.fn(async (args: any) => {
+        record("componentVersion.create", args);
+        const id = `cv-${(calls["componentVersion.create"]?.length ?? 0)}`;
+        return { id, name: args.data.name, increment: args.data.increment };
+      }),
+      findFirst: jest.fn(async () => null),
+      findMany: jest.fn(),
+    },
+    // Transition history
+    builtVersionTransition: {
+      findFirst: jest.fn(async () => ({ toStatus: "in_development" })),
+      create: jest.fn(async (args: any) => ({ id: "t1", ...args.data })),
+      findMany: jest.fn(),
+    },
+    // Users not needed beyond connect
+  };
+
+  return { db, calls } as const;
+}
+
+describe("ReleaseVersion and BuiltVersion behavior", () => {
+  test("creating a release creates an initial builtVersion named *.0 and component versions", async () => {
+    const { db, calls } = makeMockDb();
+    // Mock Release name when looked up by BuiltVersionService
+    db.releaseVersion.findUniqueOrThrow = jest.fn(async () => ({ id: "11111111-1111-1111-1111-111111111111", name: "version 100" }));
+
+    const svc = new ReleaseVersionService(db as any);
+    await svc.create("user-1" as any, "version 100");
+
+    // builtVersion created alongside
+    expect(db.builtVersion.create).toHaveBeenCalled();
+    const builtArgs = calls["builtVersion.create"][0] as any;
+    expect(builtArgs.data.name).toBe("version 100.0"); // ends with .0
+
+    // component versions created for each existing release component (2)
+    expect(db.componentVersion.create).toHaveBeenCalledTimes(2);
+  });
+
+  test("creating a builtVersion creates component versions for each release component", async () => {
+    const { db } = makeMockDb();
+    const REL2 = "22222222-2222-2222-2222-222222222222";
+    db.releaseVersion.findUniqueOrThrow = jest.fn(async () => ({ id: REL2, name: "version 200" }));
+    const bsvc = new BuiltVersionService(db as any);
+    await bsvc.create("user-1" as any, REL2 as any, "version 200.0");
+    // Two components → two component versions
+    expect(db.componentVersion.create).toHaveBeenCalledTimes(2);
+  });
+
+  test("transition to in_deployment creates a successor with higher increment", async () => {
+    const { db, calls } = makeMockDb();
+    const createdAt = new Date("2024-01-01T00:00:00Z");
+    db.builtVersion.findUnique = jest.fn(async () => ({ id: "33333333-3333-3333-3333-333333333333", name: "version 300.0", versionId: "11111111-1111-1111-1111-111111111111", createdAt }));
+    db.releaseVersion.findUnique = jest.fn(async () => ({ id: "11111111-1111-1111-1111-111111111111", name: "version 300", lastUsedIncrement: 0 }));
+    db.builtVersion.findFirst = jest.fn(async () => null); // no newer exists
+
+    const ssvc = new BuiltVersionStatusService(db as any);
+    const res = await ssvc.transition("33333333-3333-3333-3333-333333333333" as any, "startDeployment", "user-1" as any);
+    expect(res.status).toBe("in_deployment");
+
+    // Successor created with next increment (1)
+    const succ = calls["builtVersion.create"][0] as any;
+    expect(succ.data.name).toBe("version 300.1");
+  });
+
+  test("no successor is created if a newer built already exists", async () => {
+    const { db } = makeMockDb();
+    const createdAt = new Date("2024-01-01T00:00:00Z");
+    db.builtVersion.findUnique = jest.fn(async () => ({ id: "44444444-4444-4444-4444-444444444444", name: "version 400.0", versionId: "11111111-1111-1111-1111-111111111111", createdAt }));
+    db.releaseVersion.findUnique = jest.fn(async () => ({ id: "11111111-1111-1111-1111-111111111111", name: "version 400", lastUsedIncrement: 1 }));
+    // Simulate a newer build existing
+    db.builtVersion.findFirst = jest.fn(async () => ({ id: "built-NEWER" }));
+
+    const ssvc = new BuiltVersionStatusService(db as any);
+    await ssvc.transition("44444444-4444-4444-4444-444444444444" as any, "startDeployment", "user-1" as any);
+    // ensure builtVersion.create was NOT called
+    expect(db.builtVersion.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/release-version.service.test.ts
+++ b/tests/services/release-version.service.test.ts
@@ -141,5 +141,7 @@ describe("ReleaseVersion and BuiltVersion behavior", () => {
     await ssvc.transition("44444444-4444-4444-4444-444444444444" as any, "startDeployment", "user-1" as any);
     // ensure builtVersion.create was NOT called
     expect(db.builtVersion.create).not.toHaveBeenCalled();
+    // ensure no component versions were created either
+    expect(db.componentVersion.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added and reorganized guides: AGENTS.md update, README entry, detailed built-version behavior (auto-creation, increments, transitions, UI caching), and new release component naming guide with token rules and persistence.

- UI
  - Builds page: refreshes releases list after starting deployment; removed the “Add Built Version” card.

- Tests
  - Added service-level tests for release/build workflows; simplified Prisma schema path resolution and adjusted coverage.

- Chores
  - Enabled TS ESM in Jest, added test:services script, renamed test:all script, and added ts-jest devDependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->